### PR TITLE
Allow PES with stream ID other then 0

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESAudio.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESAudio.as
@@ -75,7 +75,9 @@
 				
 				value = packet.readUnsignedInt();
 				packet.position -= 4;
-				if(packet.readUnsignedInt() != 0x1c0)
+				
+				var startCode:uint =  packet.readUnsignedInt();
+				if(startCode < 0x1C0 || startCode > 0x1DF)
 				{
 						throw new Error("PES start code not found or not AAC/AVC");
 				}

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESVideo.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESVideo.as
@@ -54,7 +54,8 @@ package org.denivip.osmf.net.httpstreaming.hls
 			{
 				// start of a new PES packet
 				
-				if(packet.readUnsignedInt() != 0x1e0)
+				var startCode:uint =  packet.readUnsignedInt();
+				if(startCode < 0x1E0 || startCode > 0x1EF)
 				{
 						throw new Error("PES start code not found or not AAC/AVC");
 				}


### PR DESCRIPTION
Stream ids for video are in the range 0xE0-0xEF and for audio are in
the range 0xC0-0xDF.
