### PR TITLE
Fix error to strip 0x in front of static IV

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
@@ -250,7 +250,7 @@
 								var strip:RegExp = /"/g;
 								keyUrl = keyValue.replace(strip,"");
 							}else if(keyComponent == "IV") {
-								keyIv = keyValue;
+								keyIv = keyValue.substr(2);
 							}
 						}
 						


### PR DESCRIPTION
Sorry, I forgot to strip the 0x in front of static IV sets for AES-128. This address #9 like usual.
