### PR TITLE
Update: add absolute patch to key url (AES, only 1 line)

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
@@ -249,6 +249,7 @@
 							}else if(keyComponent == "URI") {
 								var strip:RegExp = /"/g;
 								keyUrl = keyValue.replace(strip,"");
+								if (keyUrl.search(/(ftp|file|https?):\/\//) != 0) keyUrl = rateItem.url.substr(0, rateItem.url.lastIndexOf('/') + 1) + keyUrl;
 							}else if(keyComponent == "IV") {
 								keyIv = keyValue.substr(2);
 							}


### PR DESCRIPTION
AES Key - fix relative patch issue. With relative key url plugin was downloading it from same location as "plugin.swf" (url was simply "key.dat" but should be full absolute). Correctly it should download it of course from same location as m3u8 playlist file. 
Only 1 line has to be added. 
