### PR TITLE
Fix a but where a multi-bitrate stream with differeing AAC tracks would ...

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPHLSStreamMixer.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPHLSStreamMixer.as
@@ -169,7 +169,7 @@ package org.denivip.osmf.net.httpstreaming.hls
 			clearBuffers();
 			
 			_currentTime = 0;
-			_alternateIgnored = (_alternateHandler == null);;
+			_alternateIgnored = (_alternateHandler == null);
 			updateFilters();
 			
 			if (_mediaHandler != null)

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMp3Audio2ToPESAudio.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMp3Audio2ToPESAudio.as
@@ -216,7 +216,7 @@
 						
 						_frameLength = int((144 * _bitRate * 1000 / _sampleRate ) + _padding);
 						
-						packet.position -= 4
+						packet.position -= 4;
 						
 						dStart = packet.position;
 						_audioData = new ByteArray();


### PR DESCRIPTION
...result in audio dropping out and choppy video; code was not checking to see if there had been a stream change and propertly sending a new ADTS header to the decoder.
