### PR TITLE
Fix bug where syncFound was flagged as false incorrectly

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2TSFileHandler.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2TSFileHandler.as
@@ -117,7 +117,6 @@ package org.denivip.osmf.net.httpstreaming.hls
 				}
 				else
 				{
-					_syncFound = false;
 					var packet:ByteArray = new ByteArray();
 					
 					if (_key) {
@@ -147,6 +146,7 @@ package org.denivip.osmf.net.httpstreaming.hls
 						input.readBytes(packet, 0, 187);
 					}
 					
+					_syncFound = false;
 					var result:ByteArray = processPacket(packet);
 					if (result !== null) {
 						output.writeBytes(result);


### PR DESCRIPTION
This was causing byte-level sync issues with throttled (and potentially other) streams, whereas a previous version of the HLS plugin (pre AES-128 decryption support) was working fine. After diving into the code, it seems the flag _syncFound should **not** be set to false in case we run into a _break_ statement because there are no more bytes to read.
