### PR TITLE
Relative to absolute path and slash issue - updated and moved to new class

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/elements/m3u8Classes/M3U8PlaylistParser.as
+++ b/HLSPlugin/src/org/denivip/osmf/elements/m3u8Classes/M3U8PlaylistParser.as
@@ -3,6 +3,7 @@ package org.denivip.osmf.elements.m3u8Classes
 	import flash.events.EventDispatcher;
 	
 	import org.denivip.osmf.net.HLSDynamicStreamingResource;
+	import org.denivip.osmf.utility.Url;
 	import org.osmf.events.ParseEvent;
 	import org.osmf.logging.Log;
 	import org.osmf.logging.Logger;
@@ -138,9 +139,12 @@ package org.denivip.osmf.elements.m3u8Classes
 					tempStreamingRes = baseResource as StreamingURLResource;
 					if(tempStreamingRes){
 						// var url:String = (lines[i].search(/(ftp|file|https?):\/\//) == 0) ?  lines[i] : rateItem.url.substr(0, rateItem.url.lastIndexOf('/')+1) + lines[i];
+						/*
 						var url:String = (tempDynamicRes.streamItems[0].streamName.search(/(ftp|file|https?):\/\//) == 0) 
 							? tempDynamicRes.streamItems[0].streamName 
 							: tempDynamicRes.host.substr(0, tempDynamicRes.host.lastIndexOf('/')+1) + tempDynamicRes.streamItems[0].streamName;
+						*/
+						var url:String = Url.absolute(tempDynamicRes.host, tempDynamicRes.streamItems[0].streamName);
 						result = new StreamingURLResource(
 							url,
 							tempStreamingRes.streamType,


### PR DESCRIPTION
Relative to absolute path - moved to org.denivip.osmf.utility.Url
