### PR TITLE
Fix audio and video synching in playlists with discontinuities

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingHLSIndexHandler.as
@@ -411,6 +411,8 @@
 				dispatchEvent(new HTTPStreamingEvent(HTTPStreamingEvent.FRAGMENT_DURATION, false, false, manifest[_segment].duration));
 				
 				if(manifest[_segment].discontinuity){
+					// mark as discontinuity so stream offset should be set again
+					_fileHandler.isDiscontunity = true;
 					_fileHandler.initialOffset = manifest[_segment].startTime;
 					//dispatchEvent(new HTTPHLSStreamingEvent(HTTPHLSStreamingEvent.DISCONTINUITY));
 				}

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESAudio.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESAudio.as
@@ -99,11 +99,21 @@
 				var timestamp:Number = Math.round(pts/90);
 				_haveNewTimestamp = true;
 				
-				_offset += timestamp - _prevTimestamp;
+				if(!_timestampReseted) {
+					_offset += timestamp - _prevTimestamp;
+				}
+				
+				if (_isDiscontunity || (!_streamOffsetSet && _prevTimestamp == 0)) {
+					if(timestamp > 0) {
+						_offset += timestamp;
+					}
+					_streamOffsetSet = true;
+				}
 
 				_timestamp = _initialTimestamp + _offset;
 				_prevTimestamp = timestamp;
 				_timestampReseted = false;
+				_isDiscontunity = false;
 				
 				length -= 5;
 				// no comp time for audio

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESBase.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESBase.as
@@ -35,18 +35,29 @@
 		protected var _timestamp:Number;
 		protected var _compositionTime:Number;
 		protected var _timestampReseted:Boolean = false;
+		protected var _isDiscontunity:Boolean = false;
+		protected var _streamOffsetSet:Boolean = false;
 
 		public function set initialTimestamp(value:Number):void{
 			_initialTimestamp = value;
 			_offset = 0.0;
 			_prevTimestamp = 0.0;
 			_timestampReseted = true;
+			
+			// is beginning of stream
+			if(_initialTimestamp == 0)
+				_streamOffsetSet = false;
 		}
 	    
 	    public function processES(pusi:Boolean, packet:ByteArray, flush:Boolean = false):ByteArray
 	    {
 	    	return null;
 	    }
+		
+		public function set isDiscontunity(isDiscontunity:Boolean):void {
+			_isDiscontunity = isDiscontunity;
+			_streamOffsetSet = false;
+		}
 	}
 
 

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESVideo.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2PESVideo.as
@@ -101,11 +101,21 @@ package org.denivip.osmf.net.httpstreaming.hls
 					_compositionTime = 0;
 				}
 				
-				_offset += timestamp - _prevTimestamp;
+				if(!_timestampReseted) {
+					_offset += timestamp - _prevTimestamp;
+				}
+
+				if (_isDiscontunity || (!_streamOffsetSet && _prevTimestamp == 0)) {
+					if(timestamp > 0) {
+						_offset += timestamp;
+					}
+					_streamOffsetSet = true;
+				}
 
 				_timestamp = _initialTimestamp + _offset;
 				_prevTimestamp = timestamp;
 				_timestampReseted = false;
+				_isDiscontunity = false;
 				
 				// Skip other header data.
 				packet.position += length;

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2TSFileHandler.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMP2TSFileHandler.as
@@ -232,6 +232,12 @@ package org.denivip.osmf.net.httpstreaming.hls
 			_decryptAES = null;
 		}
 		
+		public function set isDiscontunity(isDiscontunity:Boolean):void{
+			_videoPES.isDiscontunity = isDiscontunity;
+			_audioPES.isDiscontunity = isDiscontunity;
+			_mp3audioPES.isDiscontunity = isDiscontunity;
+		}
+		
 		public function set initialOffset(offset:Number):void{
 			offset *= 1000; // convert to ms
 			_videoPES.initialTimestamp = offset;

--- a/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMp3Audio2ToPESAudio.as
+++ b/HLSPlugin/src/org/denivip/osmf/net/httpstreaming/hls/HTTPStreamingMp3Audio2ToPESAudio.as
@@ -125,11 +125,21 @@
 				var timestamp:Number = Math.round(pts/90);
 				_haveNewTimestamp = true;
 				
-				_offset += timestamp - _prevTimestamp;
+				if(!_timestampReseted) {
+					_offset += timestamp - _prevTimestamp;
+				}
+				
+				if (_isDiscontunity || (!_streamOffsetSet && _prevTimestamp == 0)) {
+					if(timestamp > 0) {
+						_offset += timestamp;
+					}
+					_streamOffsetSet = true;
+				}
 
 				_timestamp = _initialTimestamp + _offset;
 				_prevTimestamp = timestamp;
 				_timestampReseted = false;
+				_isDiscontunity = false;
 				
 				length -= 5;
 				// no comp time for audio


### PR DESCRIPTION
and also when seeking into first HLS fragment after a Discontinuity

Code in last pull request #70 had issues in these cases (sorry about that)
