### PR TITLE
Correct handling of HLS URLs with slashes in the query string

### DIFF
--- a/HLSPlugin/src/org/denivip/osmf/utility/Url.as
+++ b/HLSPlugin/src/org/denivip/osmf/utility/Url.as
@@ -24,6 +24,11 @@ package org.denivip.osmf.utility
 			if (url.search(/(ftp|file|https?):\/\//) == 0)
 				return url;
 						
+			var queryStringStart:Number = rootUrl.indexOf('?');
+			if (queryStringStart != -1) {
+				rootUrl = rootUrl.substr(0, queryStringStart);
+			}
+
 			if (url.charAt(0) == '/') {
 				var urlParts:Array = rootUrl.split('/', 4);
 				rootUrl = urlParts[2]


### PR DESCRIPTION
The current version of this plugin does not handle URLs with slashes in the query string correctly. Slashes are valid characters in the query string as specified here: http://tools.ietf.org/html/rfc3986#section-3.4. The change proposed in this PR strips the query part from the base when generating absolute URLs for manifests.
